### PR TITLE
fix(ansible): Add check for head not merge during build process. 

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -10,10 +10,11 @@ jobs:
     name: Ansible Lint on PR
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
+      - name: Checkout repo
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
+        # Note: For pull requests, actions/checkout@v4 automatically checks out
+        # the PR head branch. For workflow_dispatch, it checks out the default branch.
+        # Explicitly setting ref can cause issues with PR merge commits.
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
# Problem
When a workflow runs on a pull request:
github.ref = refs/pull/123/merge (a synthetic merge commit, which might be missing) see -> https://github.com/rh-ai-quickstart/RAG/actions/runs/19473781792/job/55728065269
This merge commit may not exist if there are conflicts
You usually want the PR branch (head), not the merge commit. 

This change will always choose the right branch/commit
