### PR TITLE
Use latest-dev tag when deploying from dev

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -43,6 +43,8 @@ jobs:
           context: ${{ matrix.context }}
           file: ${{ matrix.context }}/Containerfile
           push: true
-          tags: quay.io/rh-ai-quickstart/${{ matrix.name }}:${{ steps.tag.outputs.value }}
+          tags: |
+            quay.io/rh-ai-quickstart/${{ matrix.name }}:${{ steps.tag.outputs.value }}
+            quay.io/rh-ai-quickstart/${{ matrix.name }}:latest-dev
           cache-from: type=registry,ref=quay.io/rh-ai-quickstart/${{ matrix.name }}:buildcache
           cache-to: type=registry,ref=quay.io/rh-ai-quickstart/${{ matrix.name }}:buildcache,mode=max

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -57,12 +57,16 @@ jobs:
           sed -i "s/^version: .*/version: ${{ steps.new_version.outputs.version }}/" deploy/helm/rag/Chart.yaml
           sed -i "s/^appVersion: .*/appVersion: \"${{ steps.new_version.outputs.version }}\"/" deploy/helm/rag/Chart.yaml
 
+      - name: Update image tag to use release version
+        run: |
+          sed -i "s/tag: .*/tag: ${{ steps.new_version.outputs.version }}/" deploy/helm/rag/values.yaml
+
       - name: Commit version bump
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -b release/v${{ steps.new_version.outputs.version }}
-          git add deploy/helm/rag/Chart.yaml
+          git add deploy/helm/rag/Chart.yaml deploy/helm/rag/values.yaml
           git commit -m "chore: bump version to ${{ steps.new_version.outputs.version }}"
           git push origin release/v${{ steps.new_version.outputs.version }}
 

--- a/deploy/helm/rag/values.yaml
+++ b/deploy/helm/rag/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 image:
   repository: quay.io/rh-ai-quickstart/llamastack-dist-ui
   pullPolicy: Always
-  # tag: 0.2.18
+  tag: latest-dev
 
 service:
   type: ClusterIP


### PR DESCRIPTION
- When building in dev, always push a latest-dev tag
- When deploying from dev, always use the latest-dev tag
- When creating a release PR, update the image tag to the release version, this way when the user deploys from main, they'll deploy the latest stable version.