### PR TITLE
chore: bump configure-pipeline dependency to 0.5.7

### DIFF
--- a/deploy/helm/rag/Chart.yaml
+++ b/deploy/helm/rag/Chart.yaml
@@ -15,7 +15,7 @@ dependencies:
     repository: https://rh-ai-quickstart.github.io/ai-architecture-charts
     condition: llm-service.enabled
   - name: configure-pipeline
-    version: 0.5.6
+    version: 0.5.7
     repository: https://rh-ai-quickstart.github.io/ai-architecture-charts
     condition: configure-pipeline.enabled
   - name: ingestion-pipeline


### PR DESCRIPTION
## Summary
- Updates `configure-pipeline` dependency from `0.5.6` to `0.5.7` in the RAG Helm chart
- This picks up the minio `0.5.5` subchart which includes a `secret.create` toggle

## Context
When deploying via Validated Patterns with External Secrets Operator, both the Helm chart and External Secrets create the same `minio` secret with different passwords, causing a credential mismatch on first deploy. With this dependency chain update, consumers can set `configure-pipeline.minio.secret.create: false` to let External Secrets be the sole owner.

Depends on: https://github.com/rh-ai-quickstart/ai-architecture-charts/pull/169

## Test plan
- [ ] Verify `configure-pipeline@0.5.7` resolves correctly
- [ ] Deploy with default values — existing behavior unchanged
- [ ] Deploy with `configure-pipeline.minio.secret.create: false` — minio secret not created by chart