### PR TITLE
chore(upgrade): upgrade configure pipelines to enable disable managed pipelines, and fixes for new llama-stack image.

### DIFF
--- a/deploy/helm/rag/Chart.yaml
+++ b/deploy/helm/rag/Chart.yaml
@@ -15,7 +15,7 @@ dependencies:
     repository: https://rh-ai-quickstart.github.io/ai-architecture-charts
     condition: llm-service.enabled
   - name: configure-pipeline
-    version: 0.5.7
+    version: 0.5.8
     repository: https://rh-ai-quickstart.github.io/ai-architecture-charts
     condition: configure-pipeline.enabled
   - name: ingestion-pipeline

--- a/deploy/helm/rag/values.yaml
+++ b/deploy/helm/rag/values.yaml
@@ -175,10 +175,6 @@ pgvector:
     - https://raw.githubusercontent.com/rh-ai-quickstart/RAG/refs/heads/main/notebooks/zippity-zoo/Zippity_Zoo_and_the_Town_of_Whispering_Willows.pdf
 
 llama-stack:
-  image:
-    repository: registry.redhat.io/rhoai/odh-llama-stack-core-rhel9
-    pullPolicy: Always
-    tag: "v3.4.0-ea.2"
   enabled: true
   # Needed for vector storage to work when using the llama-stack version 3.4.0-ea.2
   pgvector:

--- a/deploy/helm/rag/values.yaml
+++ b/deploy/helm/rag/values.yaml
@@ -175,7 +175,14 @@ pgvector:
     - https://raw.githubusercontent.com/rh-ai-quickstart/RAG/refs/heads/main/notebooks/zippity-zoo/Zippity_Zoo_and_the_Town_of_Whispering_Willows.pdf
 
 llama-stack:
+  image:
+    repository: registry.redhat.io/rhoai/odh-llama-stack-core-rhel9
+    pullPolicy: Always
+    tag: "v3.4.0-ea.2"
   enabled: true
+  # Needed for vector storage to work when using the llama-stack version 3.4.0-ea.2
+  pgvector:
+    enabled: true
   fileProcessors:
     enabled: true
     providers:
@@ -185,7 +192,20 @@ llama-stack:
   secrets:
     TAVILY_SEARCH_API_KEY: "Paste-your-key-here"
 
+  # The RHOAI UBI/s2i image sets HOME=/opt/app-root/src, so ~/.llama resolves
+  # to /opt/app-root/src/.llama. Override the default volumeMounts (which use
+  # /.llama) to match the actual home directory path used by the container.
+  volumeMounts:
+    - mountPath: /app-config
+      name: run-config-volume
+    - mountPath: /opt/app-root/src/.llama
+      name: dot-llama
+    - mountPath: /opt/app-root/src/.cache
+      name: cache
+
 configure-pipeline:
+  managedPipelines:
+    enabled: false
   enabled: true
   minio:
     secret:

--- a/deploy/helm/rag/values.yaml
+++ b/deploy/helm/rag/values.yaml
@@ -204,6 +204,7 @@ llama-stack:
       name: cache
 
 configure-pipeline:
+  # Set to false if you are running Openshift AI 3.4 or later and you want to disable the managed pipelines.
   managedPipelines:
     enabled: false
   enabled: true


### PR DESCRIPTION
- add new llamastack image for 0.6.0
- add volume mounts for new image paths
```
  volumeMounts:
    - mountPath: /app-config
      name: run-config-volume
    - mountPath: /opt/app-root/src/.llama
      name: dot-llama
    - mountPath: /opt/app-root/src/.cache
      name: cache
```
- enable PGvector for vector store to prevent errors.
- added managed pipelines fix for backaward compatability with 3.4 an non 3.4 versions. 