### PR TITLE
chore(upgrade): upgrade configure pipelines to enable disable managed pipelines. and fix image used in llamastack

### DIFF
--- a/deploy/helm/rag-values.yaml.example
+++ b/deploy/helm/rag-values.yaml.example
@@ -13,34 +13,11 @@
 # TAVILY Search API Key is configured in the llama-stack.secrets section below
 
 # LLM Service Configuration
-# For Agent-based chat on CPU, tool-calling args are required. Direct mode in the UI
-# avoids tool calling if you see JSON parsing errors from vLLM.
 llm-service:
-  device: cpu
   secret:
     hf_token: ""
     enabled: true
-  models:
-    llama-3-2-1b-instruct:
-      enabled: true
-      device: cpu
-      resources:
-        limits:
-          cpu: "6"
-          memory: 12Gi
-        requests:
-          cpu: "2"
-          memory: 6Gi
-      args:
-        - --enable-auto-tool-choice
-        - --chat-template
-        - /chat-templates/tool_chat_template_llama3.2_json.jinja
-        - --tool-call-parser
-        - llama3_json
-        - --max-model-len
-        - "8192"
-        - --max-num-seqs
-        - "4"
+  # device: cpu  # set when deploying llama-3-2-1b-instruct-cpu (or use DEVICE=cpu with make install)
 
 # Global model configuration
 global:
@@ -59,6 +36,33 @@ global:
         - key: "nvidia.com/gpu"
           operator: Exists
           effect: NoSchedule
+
+    # CPU variant — same Hugging Face model, separate deployment key to avoid GPU conflict.
+    # Enable this entry (and set llm-service.device: cpu) for CPU-only clusters.
+    # For Agent-based chat on CPU, tool-calling args are required. Direct mode in the UI
+    # avoids tool calling if you see JSON parsing errors from vLLM.
+    # Deploy: make install NAMESPACE=llama-stack-rag LLM=llama-3-2-1b-instruct-cpu DEVICE=cpu
+    llama-3-2-1b-instruct-cpu:
+      id: meta-llama/Llama-3.2-1B-Instruct
+      enabled: false
+      device: cpu
+      resources:
+        limits:
+          cpu: "6"
+          memory: 12Gi
+        requests:
+          cpu: "2"
+          memory: 6Gi
+      args:
+        - --enable-auto-tool-choice
+        - --chat-template
+        - /chat-templates/tool_chat_template_llama3.2_json.jinja
+        - --tool-call-parser
+        - llama3_json
+        - --max-model-len
+        - "8192"
+        - --max-num-seqs
+        - "4"
 
     llama-3-1-8b-instruct:
       id: meta-llama/Llama-3.1-8B-Instruct

--- a/deploy/helm/rag-values.yaml.example
+++ b/deploy/helm/rag-values.yaml.example
@@ -13,10 +13,34 @@
 # TAVILY Search API Key is configured in the llama-stack.secrets section below
 
 # LLM Service Configuration
+# For Agent-based chat on CPU, tool-calling args are required. Direct mode in the UI
+# avoids tool calling if you see JSON parsing errors from vLLM.
 llm-service:
+  device: cpu
   secret:
     hf_token: ""
     enabled: true
+  models:
+    llama-3-2-1b-instruct:
+      enabled: true
+      device: cpu
+      resources:
+        limits:
+          cpu: "6"
+          memory: 12Gi
+        requests:
+          cpu: "2"
+          memory: 6Gi
+      args:
+        - --enable-auto-tool-choice
+        - --chat-template
+        - /chat-templates/tool_chat_template_llama3.2_json.jinja
+        - --tool-call-parser
+        - llama3_json
+        - --max-model-len
+        - "8192"
+        - --max-num-seqs
+        - "4"
 
 # Global model configuration
 global:

--- a/deploy/helm/rag/Chart.lock
+++ b/deploy/helm/rag/Chart.lock
@@ -7,15 +7,15 @@ dependencies:
   version: 0.5.9
 - name: configure-pipeline
   repository: https://rh-ai-quickstart.github.io/ai-architecture-charts
-  version: 0.5.7
+  version: 0.5.8
 - name: ingestion-pipeline
   repository: https://rh-ai-quickstart.github.io/ai-architecture-charts
   version: 0.7.4
 - name: llama-stack
   repository: https://rh-ai-quickstart.github.io/ai-architecture-charts
-  version: 0.7.3
+  version: 0.8.6
 - name: mcp-servers
   repository: https://rh-ai-quickstart.github.io/ai-architecture-charts
   version: 0.5.15
-digest: sha256:58ad2663a8435d7d29b67670dd0deb209508a31020333b7be9501a515580f458
-generated: "2026-04-22T09:51:53.961068-04:00"
+digest: sha256:3c8f3da85c35fec034c56cd43813e80ca7c223354de23b46747e9fcc44c527e0
+generated: "2026-06-09T09:12:30.763414-04:00"

--- a/deploy/helm/rag/Chart.yaml
+++ b/deploy/helm/rag/Chart.yaml
@@ -15,7 +15,7 @@ dependencies:
     repository: https://rh-ai-quickstart.github.io/ai-architecture-charts
     condition: llm-service.enabled
   - name: configure-pipeline
-    version: 0.5.7
+    version: 0.5.8
     repository: https://rh-ai-quickstart.github.io/ai-architecture-charts
     condition: configure-pipeline.enabled
   - name: ingestion-pipeline
@@ -23,7 +23,7 @@ dependencies:
     repository: https://rh-ai-quickstart.github.io/ai-architecture-charts
     condition: ingestion-pipeline.enabled
   - name: llama-stack
-    version: 0.7.3
+    version: 0.8.6
     repository: https://rh-ai-quickstart.github.io/ai-architecture-charts
     condition: llama-stack.enabled
   - name: mcp-servers

--- a/ingestion-service/README.md
+++ b/ingestion-service/README.md
@@ -231,6 +231,47 @@ podman-compose up -d
 - Process fewer documents per pipeline
 - Use smaller embedding models
 
+### Agent Mode Fails to Return Result
+
+**Issue**: Response never returned from LLM in CPU mode.
+
+**Solution:**
+- Copy the following yaml from rag-values.yaml.example and place in 
+  rag-value.yaml file.
+- Increase resources for CPU
+- Set LLM Flags for CPU mode
+
+```yaml
+llm-service:
+  device: cpu
+  secret:
+    hf_token: ""
+    enabled: true
+  models:
+    llama-3-2-1b-instruct:
+      enabled: true
+      device: cpu
+      # increase resources start
+      resources:
+        limits:
+          cpu: "6"
+          memory: 12Gi
+        requests:
+          cpu: "2"
+          memory: 6Gi
+      # increase resources end
+      args: # Copy from here down.
+        - --enable-auto-tool-choice
+        - --chat-template
+        - /chat-templates/tool_chat_template_llama3.2_json.jinja
+        - --tool-call-parser
+        - llama3_json
+        - --max-model-len
+        - "8192"
+        - --max-num-seqs
+        - "4"
+```
+
 ## Advanced Configuration
 
 ### Custom Embedding Model


### PR DESCRIPTION
- add volume mounts for new image paths
  volumeMounts:
    - mountPath: /app-config
      name: run-config-volume
    - mountPath: /opt/app-root/src/.llama
      name: dot-llama
    - mountPath: /opt/app-root/src/.cache
      name: cache
- enable PGvector for vector store to prevent errors.
- added managed pipelines fix for backaward compatability with 3.4 an non 3.4 versions.
