### PR TITLE
Update Helm dependencies for Xeon support and 3.4.0 compatibility

### DIFF
--- a/deploy/helm/rag-values.yaml.example
+++ b/deploy/helm/rag-values.yaml.example
@@ -169,6 +169,17 @@ global:
     #     operator: Exists
     #     effect: NoSchedule
 
+    # Example Xeon configurations:
+    # llama-3-2-3b-instruct:
+    #   id: meta-llama/Llama-3.2-3B-Instruct
+    #   enabled: true
+    #   device: "xeon"
+    #   args:
+    #   - --max-model-len
+    #   - "14336"
+    #   - --max-num-seqs
+    #   - "32"
+
   # MCP servers configuration
   mcp-servers: {}
 

--- a/deploy/helm/rag/Chart.yaml
+++ b/deploy/helm/rag/Chart.yaml
@@ -7,26 +7,26 @@ appVersion: "0.2.45"
 
 dependencies:
   - name: pgvector
-    version: 0.5.5
+    version: 0.5.6
     repository: https://rh-ai-quickstart.github.io/ai-architecture-charts
     condition: pgvector.enabled
   - name: llm-service
-    version: 0.5.9
+    version: 0.5.10
     repository: https://rh-ai-quickstart.github.io/ai-architecture-charts
     condition: llm-service.enabled
   - name: configure-pipeline
-    version: 0.5.8
+    version: 0.5.9
     repository: https://rh-ai-quickstart.github.io/ai-architecture-charts
     condition: configure-pipeline.enabled
   - name: ingestion-pipeline
-    version: 0.7.4
+    version: 0.7.5
     repository: https://rh-ai-quickstart.github.io/ai-architecture-charts
     condition: ingestion-pipeline.enabled
   - name: llama-stack
-    version: 0.8.6
+    version: 0.8.7
     repository: https://rh-ai-quickstart.github.io/ai-architecture-charts
     condition: llama-stack.enabled
   - name: mcp-servers
-    version: 0.5.15
+    version: 0.5.18
     repository: https://rh-ai-quickstart.github.io/ai-architecture-charts
     condition: mcp-servers.enabled


### PR DESCRIPTION
Updated rag-values.yaml.example with Xeon model config comments

Helm dependency updates:
- pgvector: 0.5.5 → 0.5.6
- llm-service: 0.5.9 → 0.5.10
- configure-pipeline: 0.5.8 → 0.5.9
- ingestion-pipeline: 0.7.4 → 0.7.5
- llama-stack: 0.8.6 → 0.8.7
- mcp-servers: 0.5.15 → 0.5.18
