### PR TITLE
Xeon 3.4.0 fix - update chart.lock dependencies

### DIFF
--- a/deploy/helm/rag-values.yaml.example
+++ b/deploy/helm/rag-values.yaml.example
@@ -169,6 +169,17 @@ global:
     #     operator: Exists
     #     effect: NoSchedule
 
+    # Example Xeon configurations:
+    # llama-3-2-3b-instruct:
+    #   id: meta-llama/Llama-3.2-3B-Instruct
+    #   enabled: true
+    #   device: "xeon"
+    #   args:
+    #   - --max-model-len
+    #   - "14336"
+    #   - --max-num-seqs
+    #   - "32"
+    
   # MCP servers configuration
   mcp-servers: {}
 

--- a/deploy/helm/rag/Chart.lock
+++ b/deploy/helm/rag/Chart.lock
@@ -1,21 +1,21 @@
 dependencies:
 - name: pgvector
   repository: https://rh-ai-quickstart.github.io/ai-architecture-charts
-  version: 0.5.5
+  version: 0.5.6
 - name: llm-service
   repository: https://rh-ai-quickstart.github.io/ai-architecture-charts
-  version: 0.5.9
+  version: 0.5.10
 - name: configure-pipeline
   repository: https://rh-ai-quickstart.github.io/ai-architecture-charts
-  version: 0.5.8
+  version: 0.5.9
 - name: ingestion-pipeline
   repository: https://rh-ai-quickstart.github.io/ai-architecture-charts
-  version: 0.7.4
+  version: 0.7.5
 - name: llama-stack
   repository: https://rh-ai-quickstart.github.io/ai-architecture-charts
-  version: 0.8.6
+  version: 0.8.7
 - name: mcp-servers
   repository: https://rh-ai-quickstart.github.io/ai-architecture-charts
-  version: 0.5.15
-digest: sha256:3c8f3da85c35fec034c56cd43813e80ca7c223354de23b46747e9fcc44c527e0
-generated: "2026-06-09T09:12:30.763414-04:00"
+  version: 0.5.18
+digest: sha256:e0a207e133ea7ff565c5431f00272829ae9d041ac0e4869472eb06ba6b44ba58
+generated: "2026-07-13T15:48:14.880319387-07:00"

--- a/deploy/helm/rag/Chart.yaml
+++ b/deploy/helm/rag/Chart.yaml
@@ -7,26 +7,26 @@ appVersion: "0.2.38"
 
 dependencies:
   - name: pgvector
-    version: 0.5.5
+    version: 0.5.6
     repository: https://rh-ai-quickstart.github.io/ai-architecture-charts
     condition: pgvector.enabled
   - name: llm-service
-    version: 0.5.9
+    version: 0.5.10
     repository: https://rh-ai-quickstart.github.io/ai-architecture-charts
     condition: llm-service.enabled
   - name: configure-pipeline
-    version: 0.5.8
+    version: 0.5.9
     repository: https://rh-ai-quickstart.github.io/ai-architecture-charts
     condition: configure-pipeline.enabled
   - name: ingestion-pipeline
-    version: 0.7.4
+    version: 0.7.5
     repository: https://rh-ai-quickstart.github.io/ai-architecture-charts
     condition: ingestion-pipeline.enabled
   - name: llama-stack
-    version: 0.8.6
+    version: 0.8.7
     repository: https://rh-ai-quickstart.github.io/ai-architecture-charts
     condition: llama-stack.enabled
   - name: mcp-servers
-    version: 0.5.15
+    version: 0.5.18
     repository: https://rh-ai-quickstart.github.io/ai-architecture-charts
     condition: mcp-servers.enabled


### PR DESCRIPTION
update chart.lock - auto-generated when running `make list-models`