### PR TITLE
fix: build RAG UI image locally in e2e tests

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -265,6 +265,13 @@ jobs:
           kubectl get pods -A
           kubectl get crds | grep route || echo "Route CRD check"
 
+      - name: Build RAG UI image and load into Kind
+        run: |
+          IMAGE_TAG=$(grep '^version:' deploy/helm/rag/Chart.yaml | awk '{print $2}')
+          echo "Building image with tag: ${IMAGE_TAG}"
+          docker build -t quay.io/rh-ai-quickstart/llamastack-dist-ui:${IMAGE_TAG} frontend/ -f frontend/Containerfile
+          kind load docker-image quay.io/rh-ai-quickstart/llamastack-dist-ui:${IMAGE_TAG} --name rag-e2e
+
       - name: Add Helm repository
         run: |
           helm repo add rag-charts https://rh-ai-quickstart.github.io/ai-architecture-charts
@@ -601,6 +608,13 @@ jobs:
           
           kubectl wait --for condition=established --timeout=60s crd/routes.route.openshift.io
           echo "✅ All required CRDs installed successfully"
+
+      - name: Build RAG UI image and load into Kind
+        run: |
+          IMAGE_TAG=$(grep '^version:' deploy/helm/rag/Chart.yaml | awk '{print $2}')
+          echo "Building image with tag: ${IMAGE_TAG}"
+          docker build -t quay.io/rh-ai-quickstart/llamastack-dist-ui:${IMAGE_TAG} frontend/ -f frontend/Containerfile
+          kind load docker-image quay.io/rh-ai-quickstart/llamastack-dist-ui:${IMAGE_TAG} --name rag-e2e-ui
 
       - name: Add Helm repository
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,9 @@ on:
 
 jobs:
   cleanup-branch:
-    if: startsWith(github.event.pull_request.head.ref, 'release/')
+    if: |
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'release/')
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
- Build the RAG UI Docker image from source during e2e tests and load it into Kind, instead of pulling from quay.io registry
- Fixes the chicken-and-egg problem where release PRs bump the image tag before the image exists in the registry, causing `ImagePullBackOff` failures
- Fix `cleanup-branch` job in release workflow to only delete the release branch when the PR is actually merged (not just closed)

## Root Cause
The `create-release-pr` workflow bumps the image tag in `values.yaml` (e.g. to `0.2.46`), but the image is only built by the `release` job after the PR merges. E2E tests run on the PR and try to pull the not-yet-existing image, failing with `ImagePullBackOff`.

## Test plan
- [ ] Verify e2e tests pass on a release PR where the image tag has been bumped
- [ ] Verify `cleanup-branch` no longer deletes the release branch when a PR is closed without merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)